### PR TITLE
Add library check to extconf

### DIFF
--- a/ext/edlib/extconf.rb
+++ b/ext/edlib/extconf.rb
@@ -2,4 +2,5 @@
 
 require 'mkmf'
 
+have_library "edlib"
 create_makefile('edlib/edlibext')


### PR DESCRIPTION
This might alleviate the following error on some environments (e.g. Guix):

```
ruby: symbol lookup error: /.../lib/edlib/edlibext.so: undefined symbol: edlibAlign
```